### PR TITLE
Configure Jitpack to build javadoc & sources

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,2 @@
 install:
-   - mvn install -DskipTests -Prelease
+   - mvn install -DskipTests -Pjitpack

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+install:
+   - mvn install -DskipTests -Prelease

--- a/pom.xml
+++ b/pom.xml
@@ -244,5 +244,42 @@
         </plugins>
       </build>
     </profile>
+	  
+    <profile>
+      <id>jitpack</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>3.0.1</version>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>3.0.1</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <phase>package</phase> 
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
**Motivation**

I'm using [Jitpack](https://jitpack.io/) to get the latest version of TinFour as a Maven package. However, since the build does not by default include the sources and Javadoc, these aren't available on the IDE and it's pretty annoying having to jump back to GitHub to read Javadocs.

**Solution**

Add another maven profile that includes the avadoc & sources and configure jitpack to run that profile when it builds the artifact.