### PR TITLE
fix #139

### DIFF
--- a/core/src/main/java/org/tinfour/common/GeometricOperations.java
+++ b/core/src/main/java/org/tinfour/common/GeometricOperations.java
@@ -175,12 +175,33 @@ public class GeometricOperations {
     // involve squared terms.  We do not want to take a difference between
     // once of these and a non-squared term because we do not want to
     // lose precision in the low-order digits.
+    double s1 = a11 * a11 + a12 * a12;
+    double s2 = a21 * a21 + a22 * a22;
+    double s3 = a31 * a31 + a32 * a32;
+    double p1 = a21 * a32;
+    double p2 = a31 * a22;
+    double p3 = a31 * a12;
+    double p4 = a11 * a32;
+    double p5 = a11 * a22;
+    double p6 = a21 * a12;
     double inCircle
-      = (a11 * a11 + a12 * a12) * (a21 * a32 - a31 * a22)
-      + (a21 * a21 + a22 * a22) * (a31 * a12 - a11 * a32)
-      + (a31 * a31 + a32 * a32) * (a11 * a22 - a21 * a12);
+      = s1 * (p1 - p2)
+      + s2 * (p3 - p4)
+      + s3 * (p5 - p6);
 
-    if (-inCircleThreshold < inCircle && inCircle < inCircleThreshold) {
+    // Decide whether the ordinary-precision result can be trusted using an
+    // adaptive error bound (Shewchuk).  The bound scales with the magnitude of
+    // the terms actually computed, so it remains valid for input coordinates of
+    // arbitrarily large magnitude -- unlike the fixed inCircleThreshold, which
+    // is keyed to the nominal point spacing and under-escalates for coordinates
+    // whose magnitude greatly exceeds that spacing.
+    double permanent
+      = s1 * (Math.abs(p1) + Math.abs(p2))
+      + s2 * (Math.abs(p3) + Math.abs(p4))
+      + s3 * (Math.abs(p5) + Math.abs(p6));
+    double errBound = Thresholds.IN_CIRCLE_ERROR_BOUND * permanent;
+
+    if (-errBound <= inCircle && inCircle <= errBound) {
       this.nExtendedPrecisionInCircle++;
       double inCircle2 = this.inCircleQuadPrecision(ax, ay, bx, by, cx, cy, dx, dy);
 

--- a/core/src/main/java/org/tinfour/common/Thresholds.java
+++ b/core/src/main/java/org/tinfour/common/Thresholds.java
@@ -52,6 +52,31 @@ public class Thresholds {
   public static final double VERTEX_TOLERANCE_FACTOR_DEFAULT = 1.0e+5;
 
   /**
+   * The unit round-off for IEEE-754 double-precision arithmetic, 2<sup>-53</sup>.
+   * This is half of {@code Math.ulp(1.0)} and represents the maximum relative
+   * error introduced by a single rounded floating-point operation.
+   */
+  public static final double DOUBLE_PRECISION_EPSILON = 0x1.0p-53; // 2^-53 ~ 1.11e-16
+
+  /**
+   * Relative error bound for the ordinary-precision in-circle determinant.
+   * <p>
+   * Unlike the absolute thresholds above (which are keyed to the nominal point
+   * spacing), this bound is applied to a "permanent" derived from the magnitude
+   * of the terms in the determinant actually being evaluated. The result is an
+   * adaptive criterion that remains valid regardless of the magnitude of the
+   * input coordinates: whenever the magnitude of an ordinary-precision in-circle
+   * result is no larger than this bound times the permanent, the sign of the
+   * result cannot be trusted and an extended-precision evaluation is required.
+   * <p>
+   * The value follows the {@code iccerrboundA} constant from Jonathan Shewchuk's
+   * "Adaptive Precision Floating-Point Arithmetic and Fast Robust Geometric
+   * Predicates" (Discrete &amp; Computational Geometry, 1997).
+   */
+  public static final double IN_CIRCLE_ERROR_BOUND
+    = (10.0 + 96.0 * DOUBLE_PRECISION_EPSILON) * DOUBLE_PRECISION_EPSILON;
+
+  /**
    * The nominal point spacing value specified in the constructor.
    * In general, this value is a rough estimate of the
    * mean distance between neighboring points (or vertices).

--- a/core/src/main/java/org/tinfour/semivirtual/SemiVirtualIncrementalTin.java
+++ b/core/src/main/java/org/tinfour/semivirtual/SemiVirtualIncrementalTin.java
@@ -790,7 +790,23 @@ public class SemiVirtualIncrementalTin implements IIncrementalTin {
     n2.setForward(n0);
 
     final SemiVirtualEdge c = searchEdge.copy();
+    // Safety guard against a non-terminating cavity construction.  In a
+    // well-formed mesh the walk around the insertion cavity returns to the
+    // anchor in fewer steps than there are edges in the TIN.  If numerically
+    // degenerate input produces an inconsistent (non-star-shaped) cavity, the
+    // exit condition (c.getB() == anchor) may never be met; rather than loop
+    // forever we throw so that the caller can recover (see issue #139).
+    final int maxInsertionSteps = 2 * edgePool.size() + 16;
+    int nInsertionSteps = 0;
     while (true) {
+      if (++nInsertionSteps > maxInsertionSteps) {
+        throw new IllegalStateException(
+          "Vertex insertion failed to converge near ("
+          + x + ", " + y + "), most likely due to numerically degenerate"
+          + " input. Consider constructing the TIN with a nominal point"
+          + " spacing representative of the sample data"
+          + " (e.g. new SemiVirtualIncrementalTin(spacing)).");
+      }
       n0.loadDualFromEdge(c);   //n0 = c.getDual();
       n1.loadForwardFromEdge(n0); // = n0.getForward();
 
@@ -822,10 +838,26 @@ public class SemiVirtualIncrementalTin implements IIncrementalTin {
         double a22 = vB.y - y;
         double a32 = vC.y - y;
 
-        h = (a11 * a11 + a12 * a12) * (a21 * a32 - a31 * a22)
-          + (a21 * a21 + a22 * a22) * (a31 * a12 - a11 * a32)
-          + (a31 * a31 + a32 * a32) * (a11 * a22 - a21 * a12);
-        if (inCircleThresholdNeg < h && h < inCircleThreshold) {
+        double s1 = a11 * a11 + a12 * a12;
+        double s2 = a21 * a21 + a22 * a22;
+        double s3 = a31 * a31 + a32 * a32;
+        double p1 = a21 * a32;
+        double p2 = a31 * a22;
+        double p3 = a31 * a12;
+        double p4 = a11 * a32;
+        double p5 = a11 * a22;
+        double p6 = a21 * a12;
+        h = s1 * (p1 - p2) + s2 * (p3 - p4) + s3 * (p5 - p6);
+        // Adaptive error bound (Shewchuk): escalate to extended precision when
+        // the ordinary-precision result is too small to have a trustworthy sign
+        // relative to the magnitude of the terms.  Scale-invariant; avoids the
+        // under-escalation of the fixed inCircleThreshold for large-magnitude
+        // coordinates.
+        double permanent = s1 * (Math.abs(p1) + Math.abs(p2))
+          + s2 * (Math.abs(p3) + Math.abs(p4))
+          + s3 * (Math.abs(p5) + Math.abs(p6));
+        double errBound = Thresholds.IN_CIRCLE_ERROR_BOUND * permanent;
+        if (-errBound <= h && h <= errBound) {
           nInCircleExtendedPrecision++;
           double h2 = h;
           h = geoOp.inCircleQuadPrecision(
@@ -3062,7 +3094,23 @@ public class SemiVirtualIncrementalTin implements IIncrementalTin {
       c.loadFromEdge(searchEdge);
     }
 
+    // Safety guard against a non-terminating cavity construction.  In a
+    // well-formed mesh the walk around the insertion cavity returns to the
+    // anchor in fewer steps than there are edges in the TIN.  If numerically
+    // degenerate input produces an inconsistent (non-star-shaped) cavity, the
+    // exit condition (c.getB() == anchor) may never be met; rather than loop
+    // forever we throw so that the caller can recover (see issue #139).
+    final int maxInsertionSteps = 2 * edgePool.size() + 16;
+    int nInsertionSteps = 0;
     while (true) {
+      if (++nInsertionSteps > maxInsertionSteps) {
+        throw new IllegalStateException(
+          "Vertex insertion failed to converge near ("
+          + x + ", " + y + "), most likely due to numerically degenerate"
+          + " input. Consider constructing the TIN with a nominal point"
+          + " spacing representative of the sample data"
+          + " (e.g. new SemiVirtualIncrementalTin(spacing)).");
+      }
       n0.loadDualFromEdge(c);   //n0 = c.getDual();
       n1.loadForwardFromEdge(n0); // = n0.getForward();
 
@@ -3094,10 +3142,26 @@ public class SemiVirtualIncrementalTin implements IIncrementalTin {
         double a22 = vB.y - y;
         double a32 = vC.y - y;
 
-        h = (a11 * a11 + a12 * a12) * (a21 * a32 - a31 * a22)
-          + (a21 * a21 + a22 * a22) * (a31 * a12 - a11 * a32)
-          + (a31 * a31 + a32 * a32) * (a11 * a22 - a21 * a12);
-        if (inCircleThresholdNeg < h && h < inCircleThreshold) {
+        double s1 = a11 * a11 + a12 * a12;
+        double s2 = a21 * a21 + a22 * a22;
+        double s3 = a31 * a31 + a32 * a32;
+        double p1 = a21 * a32;
+        double p2 = a31 * a22;
+        double p3 = a31 * a12;
+        double p4 = a11 * a32;
+        double p5 = a11 * a22;
+        double p6 = a21 * a12;
+        h = s1 * (p1 - p2) + s2 * (p3 - p4) + s3 * (p5 - p6);
+        // Adaptive error bound (Shewchuk): escalate to extended precision when
+        // the ordinary-precision result is too small to have a trustworthy sign
+        // relative to the magnitude of the terms.  Scale-invariant; avoids the
+        // under-escalation of the fixed inCircleThreshold for large-magnitude
+        // coordinates.
+        double permanent = s1 * (Math.abs(p1) + Math.abs(p2))
+          + s2 * (Math.abs(p3) + Math.abs(p4))
+          + s3 * (Math.abs(p5) + Math.abs(p6));
+        double errBound = Thresholds.IN_CIRCLE_ERROR_BOUND * permanent;
+        if (-errBound <= h && h <= errBound) {
           nInCircleExtendedPrecision++;
           double h2 = h;
           h = geoOp.inCircleQuadPrecision(

--- a/core/src/main/java/org/tinfour/standard/IncrementalTin.java
+++ b/core/src/main/java/org/tinfour/standard/IncrementalTin.java
@@ -930,7 +930,23 @@ public class IncrementalTin implements IIncrementalTin {
     n2.setForward(p.getDual());
 
     c = searchEdge;
+    // Safety guard against a non-terminating cavity construction.  In a
+    // well-formed mesh the walk around the insertion cavity returns to the
+    // anchor in fewer steps than there are edges in the TIN.  If numerically
+    // degenerate input produces an inconsistent (non-star-shaped) cavity, the
+    // exit condition (c.getB() == anchor) may never be met; rather than loop
+    // forever we throw so that the caller can recover (see issue #139).
+    final int maxInsertionSteps = 2 * edgePool.size() + 16;
+    int nInsertionSteps = 0;
     while (true) {
+      if (++nInsertionSteps > maxInsertionSteps) {
+        throw new IllegalStateException(
+          "Vertex insertion failed to converge near ("
+          + x + ", " + y + "), most likely due to numerically degenerate"
+          + " input. Consider constructing the TIN with a nominal point"
+          + " spacing representative of the sample data"
+          + " (e.g. new IncrementalTin(spacing)).");
+      }
       n0 = c.getDual();
       n1 = n0.getForward();
 
@@ -962,10 +978,26 @@ public class IncrementalTin implements IIncrementalTin {
         double a22 = vB.y - y;
         double a32 = vC.y - y;
 
-        h = (a11 * a11 + a12 * a12) * (a21 * a32 - a31 * a22)
-          + (a21 * a21 + a22 * a22) * (a31 * a12 - a11 * a32)
-          + (a31 * a31 + a32 * a32) * (a11 * a22 - a21 * a12);
-        if (inCircleThresholdNeg < h && h < inCircleThreshold) {
+        double s1 = a11 * a11 + a12 * a12;
+        double s2 = a21 * a21 + a22 * a22;
+        double s3 = a31 * a31 + a32 * a32;
+        double p1 = a21 * a32;
+        double p2 = a31 * a22;
+        double p3 = a31 * a12;
+        double p4 = a11 * a32;
+        double p5 = a11 * a22;
+        double p6 = a21 * a12;
+        h = s1 * (p1 - p2) + s2 * (p3 - p4) + s3 * (p5 - p6);
+        // Adaptive error bound (Shewchuk): escalate to extended precision
+        // whenever the ordinary-precision result is too small to have a
+        // trustworthy sign relative to the magnitude of the terms involved.
+        // This is scale-invariant and avoids the under-escalation of the
+        // fixed inCircleThreshold for large-magnitude coordinates.
+        double permanent = s1 * (Math.abs(p1) + Math.abs(p2))
+          + s2 * (Math.abs(p3) + Math.abs(p4))
+          + s3 * (Math.abs(p5) + Math.abs(p6));
+        double errBound = Thresholds.IN_CIRCLE_ERROR_BOUND * permanent;
+        if (-errBound <= h && h <= errBound) {
           nInCircleExtendedPrecision++;
           double h2 = h;
           h = geoOp.inCircleQuadPrecision(
@@ -1297,7 +1329,19 @@ public class IncrementalTin implements IIncrementalTin {
       }
     }
 
+    // Safety guard against a non-terminating cavity construction; see the
+    // corresponding note in addWithInsertOrAppend and issue #139.
+    final int maxInsertionSteps = 2 * edgePool.size() + 16;
+    int nInsertionSteps = 0;
     while (true) {
+      if (++nInsertionSteps > maxInsertionSteps) {
+        throw new IllegalStateException(
+          "Vertex insertion failed to converge near ("
+          + x + ", " + y + "), most likely due to numerically degenerate"
+          + " input. Consider constructing the TIN with a nominal point"
+          + " spacing representative of the sample data"
+          + " (e.g. new IncrementalTin(spacing)).");
+      }
       n0 = c.getDual();
       n1 = n0.getForward();
 
@@ -1329,10 +1373,22 @@ public class IncrementalTin implements IIncrementalTin {
         double a22 = vB.y - y;
         double a32 = vC.y - y;
 
-        h = (a11 * a11 + a12 * a12) * (a21 * a32 - a31 * a22)
-          + (a21 * a21 + a22 * a22) * (a31 * a12 - a11 * a32)
-          + (a31 * a31 + a32 * a32) * (a11 * a22 - a21 * a12);
-        if (inCircleThresholdNeg < h && h < inCircleThreshold) {
+        double s1 = a11 * a11 + a12 * a12;
+        double s2 = a21 * a21 + a22 * a22;
+        double s3 = a31 * a31 + a32 * a32;
+        double p1 = a21 * a32;
+        double p2 = a31 * a22;
+        double p3 = a31 * a12;
+        double p4 = a11 * a32;
+        double p5 = a11 * a22;
+        double p6 = a21 * a12;
+        h = s1 * (p1 - p2) + s2 * (p3 - p4) + s3 * (p5 - p6);
+        // Adaptive error bound (Shewchuk): see addWithInsertOrAppend.
+        double permanent = s1 * (Math.abs(p1) + Math.abs(p2))
+          + s2 * (Math.abs(p3) + Math.abs(p4))
+          + s3 * (Math.abs(p5) + Math.abs(p6));
+        double errBound = Thresholds.IN_CIRCLE_ERROR_BOUND * permanent;
+        if (-errBound <= h && h <= errBound) {
           nInCircleExtendedPrecision++;
           double h2 = h;
           h = geoOp.inCircleQuadPrecision(


### PR DESCRIPTION
I know you're investigating too, but I pointed Claude at the problem, instructing to fix the issue with solution that is adaptive with negligible overhead.

> Tinfour's in-circle (Delaunay) predicate decided whether to fall back to its existing exact quad-precision path using a static, absolute threshold (inCircleThreshold) derived from the nominal point spacing (≈ 5.96e-8 for the default constructor). With the issue's large-magnitude coordinates (~3.2e7), the determinant's floating-point round-off error vastly exceeds that threshold, so a wrong-signed fast result was trusted instead of escalating. Inconsistent predicate results produced a non-star-shaped insertion cavity, so the cavity-construction loop's only exit (c.getB() == anchor) was never reached — an infinite loop.